### PR TITLE
Disable pointer on free space

### DIFF
--- a/src/components/Space/Space.js
+++ b/src/components/Space/Space.js
@@ -19,6 +19,7 @@ const FreeSpaceContainer = styled(SpaceContainer)`
     // override the scaling back to default for free space
     scale: 1;
   }
+  cursor: auto;
 `;
 
 export const Space = ({ id, onAction, children }) => {


### PR DESCRIPTION
Since the free space is always marked and nothing happens when you click on it, it makes sense to not have the pointer cursor when hovering over it.