### PR TITLE
Use small viewport height

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -30,6 +30,8 @@ const sampleBuzzwords = [
 
 const BuzzwordBingo = styled.div`
   min-height: 100vh;
+  // use small viewport height if browser supported
+  min-height: 100svh;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
`min-height: 100vh` still scrolls on iOS mobile browsers. 

Some browsers have a dynamic viewport size. For example, iOS Safari hides the address bar when scrolling. `svh` is the viewport height when the the address bar is in view, and `vh`/`lvh` is the viewport height when the address bar in retracted. [read more here](https://github.com/jtaavola/dynamic-viewport-demo).

Using `svh` improves mobile experience.